### PR TITLE
Fix some compiler warnings and resource leaks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,15 @@
+2017-11-28: Travis Finkenauer <tmfink@juniper.net>:
+
+	* edit_dist.c: Include edit_dist.h to pick up forward declaration of
+	  edit_distn().
+	* engine.cpp (display_result): Initialize before use in case of
+	  uncaught exception.
+	* filedata.h (class Filedata): Avoid unused variable warning.
+	* find-file-size.c: Add function prototypes for find_dev_size() and
+	  find_file_size() to keep compiler happy.
+	* fuzzy.c (fuzzy_hash_file): Avoid a memory leak.
+	* match.cpp (sig_file_close): Fix reversed logic to close handle.
+
 2017-06-01: Tsukasa OI <floss_ssdeep@irq.a4lg.com>:
 
 	* fuzzy.c, sum_table.h: Added many optimizations

--- a/edit_dist.c
+++ b/edit_dist.c
@@ -47,6 +47,7 @@ int edit_distn(const char *s1, size_t s1len, const char *s2, size_t s2len) {
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include "edit_dist.h"
 
 #define HELLOWORLD "Hello World!"
 

--- a/engine.cpp
+++ b/engine.cpp
@@ -9,7 +9,7 @@
 bool display_result(state *s, const TCHAR * fn, const char * sum) {
   // Only spend the extra time to make a Filedata object if we need to
   if (MODE(mode_match_pretty) or MODE(mode_match) or MODE(mode_directory)) {
-    Filedata * f;
+    Filedata * f = NULL;
     
     try {
       f = new Filedata(fn, sum);

--- a/filedata.h
+++ b/filedata.h
@@ -52,7 +52,7 @@ class Filedata
   ~Filedata() { if (m_filename) { free(m_filename); } }
 
  private:
-  Filedata(const Filedata &other) { assert(false); /* never copy */ }
+  Filedata(const Filedata &other) { (void) other; assert(false); /* never copy */ }
 
   std::set<Filedata *> * m_cluster;
 

--- a/find-file-size.c
+++ b/find-file-size.c
@@ -7,6 +7,11 @@
 
 #include "main.h"
 
+// Prototypes
+off_t find_file_size(FILE *f);
+off_t find_dev_size(int fd, int blk_size);
+
+
 #ifndef _WIN32
 
 // Return the size, in bytes of an open file stream. On error, return 0 

--- a/fuzzy.c
+++ b/fuzzy.c
@@ -583,7 +583,7 @@ out:
   if (status == 0)
   {
     if (fseeko(handle, fpos, SEEK_SET) < 0)
-      return -1;
+      status = -1;
   }
   fuzzy_free(ctx);
   return status;

--- a/match.cpp
+++ b/match.cpp
@@ -127,7 +127,7 @@ bool sig_file_close(state *s)
 
   free(s->known_fn);
 
-  if (s->known_handle != NULL) 
+  if (s->known_handle == NULL)
     return true;
 
   if (fclose(s->known_handle))


### PR DESCRIPTION
* `edit_dist.c`: Include edit_dist.h to pick up forward declaration of
  `edit_distn()`.
* `engine.cpp` (`display_result`): Initialize before use in case of uncaught
  exception.
* `filedata.h` (class Filedata): Avoid unused variable warning.
* `find-file-size.c`: Add function prototypes for `find_dev_size()` and
  `find_file_size()` to keep compiler happy.
* `fuzzy.c` (fuzzy_hash_file): Avoid a memory leak.
* `match.cpp` (sig_file_close): Fix reversed logic to close handle.