### PR TITLE
- fixed and/or/not (replaced by C++ syntax)

### DIFF
--- a/dig.cpp
+++ b/dig.cpp
@@ -168,7 +168,7 @@ void remove_double_dirs(TCHAR *fn)
 
 static void clean_name(state *s, TCHAR *fn)
 {
-  if (not (s->mode & mode_relative)) {
+  if (! (s->mode & mode_relative)) {
     remove_double_slash(fn);
     remove_single_dirs(fn);
     remove_double_dirs(fn);
@@ -446,7 +446,7 @@ bool process_win32(state *s, TCHAR *fn)
   TCHAR dirname[SSDEEP_PATH_MAX], new_fn[SSDEEP_PATH_MAX], expanded_fn[SSDEEP_PATH_MAX];
   WIN32_FIND_DATAW FindFileData;
 
-  if (NULL == s or NULL == fn)
+  if (NULL == s || NULL == fn)
     return true;
 
   //print_status("process_win32 got %S", fn);
@@ -460,7 +460,7 @@ bool process_win32(state *s, TCHAR *fn)
   // as an error or use it to alias the current working directory on c:.
   // As a convenience to users, we're going to accept 'c:'. To do this
   // we change it into 'c:\'
-  if (_tcslen(fn) == 2 and isalpha(fn[0]) and fn[1] == _TEXT(':')) {
+  if (_tcslen(fn) == 2 && isalpha(fn[0]) && fn[1] == _TEXT(':')) {
     fn[2] = _TEXT(DIR_SEPARATOR);
     fn[3] = 0;
   }
@@ -484,8 +484,8 @@ bool process_win32(state *s, TCHAR *fn)
 
   // If we don't have it already, create the expanded filename.
   // "C:\foo\bar.txt" --> "\\?\C:\foo\bar.txt"
-  if (not expanded_path(fn) and
-      not (s->mode & mode_relative)) {
+  if (! expanded_path(fn) &&
+      ! (s->mode & mode_relative)) {
     _sntprintf(expanded_fn,
 	       SSDEEP_PATH_MAX,
 	       _TEXT("\\\\?\\%s"),
@@ -503,8 +503,8 @@ bool process_win32(state *s, TCHAR *fn)
     // original filename, e.g. C:\foo\*. When this happens it means we just
     // didn't find any matching files.
     // Note that we still display errors with the original 'fn'
-    if (not _tcsstr(fn, _TEXT("*")))
-      print_error_unicode(s, fn, "No such file or directory");
+    if (! _tcsstr(fn, _TEXT("*")))
+      print_error_unicode(s, fn, "No such file || directory");
     return false;
   }
 
@@ -521,7 +521,7 @@ bool process_win32(state *s, TCHAR *fn)
     // Because the wildcard is always in the last part of the input
     // (e.g. c:\bin\*.exe) we can use the original dirname, combined
     // with the filename we've found, to make the new filename.
-    if (not is_special_dir(FindFileData.cFileName)) {
+    if (! is_special_dir(FindFileData.cFileName)) {
 
       //      print_status("Found file: %S", FindFileData.cFileName);
 
@@ -530,8 +530,8 @@ bool process_win32(state *s, TCHAR *fn)
 		 _TEXT("%s%s"),
 		 dirname,
 		 FindFileData.cFileName);
-      if (not expanded_path(new_fn) and
-	  not (s->mode & mode_relative)) {
+      if (! expanded_path(new_fn) &&
+	  ! (s->mode & mode_relative)) {
 	_sntprintf(expanded_fn,
 		   SSDEEP_PATH_MAX,
 		   _TEXT("\\\\?\\%s"),

--- a/dig.cpp
+++ b/dig.cpp
@@ -504,7 +504,7 @@ bool process_win32(state *s, TCHAR *fn)
     // didn't find any matching files.
     // Note that we still display errors with the original 'fn'
     if (! _tcsstr(fn, _TEXT("*")))
-      print_error_unicode(s, fn, "No such file || directory");
+      print_error_unicode(s, fn, "No such file or directory");
     return false;
   }
 

--- a/engine.cpp
+++ b/engine.cpp
@@ -1,4 +1,4 @@
-// $Id$
+// $Id$ 
 
 #include "main.h"
 #include "ssdeep.h"
@@ -8,8 +8,8 @@
 
 bool display_result(state *s, const TCHAR * fn, const char * sum) {
   // Only spend the extra time to make a Filedata object if we need to
-  if (MODE(mode_match_pretty) or MODE(mode_match) or MODE(mode_directory)) {
-    Filedata * f = NULL;
+  if (MODE(mode_match_pretty) || MODE(mode_match) || MODE(mode_directory)) {
+    Filedata * f;
     
     try {
       f = new Filedata(fn, sum);
@@ -23,7 +23,7 @@ bool display_result(state *s, const TCHAR * fn, const char * sum) {
 	print_error_unicode(s, fn, "Unable to add hash to set of known hashes");
     }
     else {
-      // This block is for MODE(mode_match) or MODE(mode_directory)
+      // This block is for MODE(mode_match) || MODE(mode_directory)
       match_compare(s, f);
       
       if (MODE(mode_directory)) {
@@ -63,10 +63,10 @@ int hash_file(state *s, TCHAR *fn) {
 
 #ifdef WIN32
   TCHAR expanded_fn[SSDEEP_PATH_MAX];
-  if (not expanded_path(fn) && !(s->mode & mode_relative)) {
-    _sntprintf(expanded_fn,
+  if (! expanded_path(fn) && !(s->mode & mode_relative)) {
+    _sntprintf(expanded_fn, 
 	       SSDEEP_PATH_MAX,
-	       _TEXT("\\\\?\\%s"),
+	       _TEXT("\\\\?\\%s"), 
 	       fn);
   } else {
     _tcsncpy(expanded_fn, fn, SSDEEP_PATH_MAX);

--- a/filedata.cpp
+++ b/filedata.cpp
@@ -59,7 +59,7 @@ void Filedata::clear_cluster(void)
 Filedata::Filedata(const TCHAR * fn, const char * sig, const char * match_file)
 {
   m_signature = std::string(sig);
-  if (not valid())
+  if (! valid())
     throw std::bad_alloc();
 
   m_filename = _tcsdup(fn);
@@ -101,7 +101,7 @@ Filedata::Filedata(const std::string& sig, const char * match_file)
     m_signature = std::string(sig);
 
     // We still have to check the validity of the signature
-    if (not valid())
+    if (! valid())
       throw std::bad_alloc();
 
     return;
@@ -163,11 +163,11 @@ bool operator==(const Filedata& a, const Filedata& b)
 {
   if (a.get_signature() != b.get_signature())
     return false;
-  if (a.has_match_file() and not b.has_match_file())
+  if (a.has_match_file() && ! b.has_match_file())
     return false;
-  if (not a.has_match_file() and b.has_match_file())
+  if (! a.has_match_file() && b.has_match_file())
     return false;
-  if (a.has_match_file() and b.has_match_file())
+  if (a.has_match_file() && b.has_match_file())
   {
     if (a.get_match_file() != b.get_match_file())
       return false;

--- a/find-file-size.c
+++ b/find-file-size.c
@@ -42,7 +42,7 @@ off_t find_file_size(FILE *f)
 #else
     // If we can't run the ioctl call, we can't do anything here
     return 0;
-#endif // ifdefined _IO and BLKGETSIZE
+#endif // ifdefined _IO && BLKGETSIZE
 
 
 #if defined(_IO) && defined(BLKSSZGET)
@@ -54,7 +54,7 @@ off_t find_file_size(FILE *f)
       sector_size = 512;
 #else
     sector_size = 512;
-#endif  // ifdef _IO and BLKSSZGET
+#endif  // ifdef _IO && BLKSSZGET
 
     return (num_sectors * sector_size);
   }

--- a/main.cpp
+++ b/main.cpp
@@ -10,6 +10,7 @@
 
 #include "ssdeep.h"
 #include "match.h"
+#include "fcntl.h"
 
 #ifdef _WIN32 
 // This can't go in main.h or we get multiple definitions of it
@@ -131,7 +132,7 @@ static void process_cmd_line(state *s, int argc, char **argv)
       if (MODE(mode_compare_unknown) || MODE(mode_sigcompare))
 	fatal_error("Positive matching cannot be combined with other matching modes");
       s->mode |= mode_match;
-      if (not match_load(s,optarg))
+      if (! match_load(s,optarg))
 	match_files_loaded = TRUE;
       break;
       
@@ -139,7 +140,7 @@ static void process_cmd_line(state *s, int argc, char **argv)
       if (MODE(mode_match) || MODE(mode_sigcompare))
 	fatal_error("Signature matching cannot be combined with other matching modes");
       s->mode |= mode_compare_unknown;
-      if (not match_load(s,optarg))
+      if (! match_load(s,optarg))
 	match_files_loaded = TRUE;
       break;
 
@@ -162,7 +163,7 @@ static void process_cmd_line(state *s, int argc, char **argv)
   // the command line arguments.
   sanity_check(s,
 	       ((MODE(mode_match) || MODE(mode_compare_unknown))
-		&& not match_files_loaded),
+		&& ! match_files_loaded),
 	       "No matching files loaded");
   
   sanity_check(s,
@@ -174,15 +175,15 @@ static void process_cmd_line(state *s, int argc, char **argv)
 	       "Directory mode and pretty matching are mutually exclusive");
 
   sanity_check(s,
-	       MODE(mode_csv) and MODE(mode_cluster),
+	       MODE(mode_csv) && MODE(mode_cluster),
 	       "CSV and clustering modes cannot be combined");
 
   // -m, -p, and -d are incompatible with -k and -x
   // The former treat FILES as raw files. The latter require them to be sigs
   sanity_check(s,
-	       ((MODE(mode_match) or MODE(mode_match_pretty) or MODE(mode_directory))
-		and
-		(MODE(mode_compare_unknown) or MODE(mode_sigcompare))),
+	       ((MODE(mode_match) || MODE(mode_match_pretty) || MODE(mode_directory))
+		&&
+		(MODE(mode_compare_unknown) || MODE(mode_sigcompare))),
 	       "Incompatible matching modes");
 
 
@@ -214,7 +215,7 @@ static int is_absolute_path(TCHAR *fn)
     internal_error("Unknown error in is_absolute_path");
   
 #ifdef _WIN32
-  return (isalpha(fn[0]) and _TEXT(':') == fn[1]);
+  return (isalpha(fn[0]) && _TEXT(':') == fn[1]);
 # else
   return (DIR_SEPARATOR == fn[0]);
 #endif
@@ -292,7 +293,7 @@ int main(int argc, char **argv)
     // on it on Win32 (i.e. where it matters). The setting of 'goal'
     // to the original argc occured at the start of main(), so we just
     // need to update it if we're *not* in signature compare mode.
-    if (not (s->mode & mode_sigcompare)) {
+    if (! (s->mode & mode_sigcompare)) {
       goal = s->argc;
     }
     
@@ -319,7 +320,7 @@ int main(int argc, char **argv)
     // to be meaningful, we should display a warning message to the user.
     // This happens mostly when people are testing very small files
     // e.g. $ echo "hello world" > foo && ssdeep foo
-    if ((not s->found_meaningful_file) and s->processed_file)
+    if ((! s->found_meaningful_file) && s->processed_file)
     {
       print_error(s,"%s: Did not process files large enough to produce meaningful results", __progname);
     }
@@ -331,7 +332,7 @@ int main(int argc, char **argv)
   // work for us.
   if (MODE(mode_sigcompare))
     s->mode |= mode_match_pretty;
-  if (MODE(mode_match_pretty) or MODE(mode_sigcompare) or MODE(mode_cluster))
+  if (MODE(mode_match_pretty) || MODE(mode_sigcompare) || MODE(mode_cluster))
     find_matches_in_known(s);
   if (MODE(mode_cluster))
     display_clusters(s);

--- a/main.h
+++ b/main.h
@@ -30,9 +30,13 @@
 #include <errno.h>
 #include <limits.h>
 #include <sys/stat.h>
+#ifndef _WIN32
 #include <unistd.h>
+#endif
 #include <ctype.h>
+#ifndef _WIN32
 #include <inttypes.h>
+#endif
 
 #ifdef HAVE_DIRENT_H
 # include <dirent.h>

--- a/match.cpp
+++ b/match.cpp
@@ -19,6 +19,7 @@
 
 
 #include "match.h"
+#include <algorithm>
 
 // The longest line we should encounter when reading files of known hashes 
 #define MAX_STR_LEN  2048
@@ -301,7 +302,7 @@ bool match_compare(state *s, Filedata * f)
     {
       if (!(_tcsncmp(f->get_filename(),
 		     (*it)->get_filename(),
-		     max(fn_len,_tcslen((*it)->get_filename())))) &&
+		     std::max(fn_len,_tcslen((*it)->get_filename())))) &&
 	  (f->get_signature() == (*it)->get_signature()))
       {
 	// Unless these results from different matching files (such as

--- a/match.cpp
+++ b/match.cpp
@@ -37,7 +37,7 @@
 /// @return Returns false success, true on error
 bool sig_file_open(state *s, const char * fn)
 {
-  if (NULL == s or NULL == fn)
+  if (NULL == s || NULL == fn)
     return true;
 
   s->known_handle = fopen(fn,"rb");
@@ -60,7 +60,7 @@ bool sig_file_open(state *s, const char * fn)
 
   chop_line(buffer);
 
-  if (strncmp(buffer,SSDEEPV1_0_HEADER,MAX_STR_LEN) and 
+  if (strncmp(buffer,SSDEEPV1_0_HEADER,MAX_STR_LEN) && 
       strncmp(buffer,SSDEEPV1_1_HEADER,MAX_STR_LEN)) 
   {
     if ( ! (MODE(mode_silent)) )
@@ -88,7 +88,7 @@ bool sig_file_open(state *s, const char * fn)
 /// Otherwise, false.
 bool sig_file_next(state *s, Filedata ** f)
 {
-  if (NULL == s or NULL == f or NULL == s->known_handle)
+  if (NULL == s || NULL == f || NULL == s->known_handle)
     return true;
 
   char buffer[MAX_STR_LEN];
@@ -220,19 +220,19 @@ void handle_clustering(state *s, Filedata *a, Filedata *b)
   bool a_has = a->has_cluster(), b_has = b->has_cluster();
 
   // In the easiest case, one of these has a cluster and one doesn't
-  if (a_has and not b_has)
+  if (a_has && ! b_has)
   {
     cluster_add(a,b);
     return;
   }
-  if (b_has and not a_has)
+  if (b_has && ! a_has)
   {
     cluster_add(b,a);
     return;
   }
   
   // Combine existing clusters
-  if (a_has and b_has)
+  if (a_has && b_has)
   {
     cluster_join(s,a,b);
     return;
@@ -301,14 +301,14 @@ bool match_compare(state *s, Filedata * f)
     {
       if (!(_tcsncmp(f->get_filename(),
 		     (*it)->get_filename(),
-		     std::max(fn_len,_tcslen((*it)->get_filename())))) and
+		     max(fn_len,_tcslen((*it)->get_filename())))) &&
 	  (f->get_signature() == (*it)->get_signature()))
       {
 	// Unless these results from different matching files (such as
 	// what happens in sigcompare mode). That being said, we have to
 	// be careful to avoid NULL values such as when working in 
 	// normal pretty print mode.
-	if (not(f->has_match_file()) or 
+	if (!(f->has_match_file()) || 
 	    f->get_match_file() == (*it)->get_match_file())
 	  continue;
       }
@@ -320,7 +320,7 @@ bool match_compare(state *s, Filedata * f)
       print_error(s, "%s: Bad hashes in comparison", __progname);
     else
     {
-      if (score > s->threshold or MODE(mode_display_all))
+      if (score > s->threshold || MODE(mode_display_all))
       {
 	handle_match(s,f,(*it),score);
 	status = true;
@@ -345,7 +345,7 @@ bool find_matches_in_known(state *s)
     // In pretty mode and sigcompare mode we need to display a blank
     // line after each file. In clustering mode we don't display anything
     // right now.
-    if (status and not(MODE(mode_cluster)))
+    if (status && !(MODE(mode_cluster)))
       print_status("");
   }
 
@@ -364,7 +364,7 @@ bool match_add(state *s, Filedata * f) {
 
 
 bool match_load(state *s, const char *fn) {
-  if (NULL == s or NULL == fn)
+  if (NULL == s || NULL == fn)
     return true;
   
   if (sig_file_open(s,fn))
@@ -375,7 +375,7 @@ bool match_load(state *s, const char *fn) {
   do {
     Filedata * f; 
     status = sig_file_next(s,&f);
-    if (not status) {
+    if (! status) {
       if (match_add(s,f)) {
 	// One bad hash doesn't mean this load was a failure.
 	// We don't change the return status because match_add failed.
@@ -383,7 +383,7 @@ bool match_load(state *s, const char *fn) {
 	break;
       }
     }
-  } while (not sig_file_end(s));
+  } while (! sig_file_end(s));
 
   sig_file_close(s);
 
@@ -393,7 +393,7 @@ bool match_load(state *s, const char *fn) {
 
 bool match_compare_unknown(state *s, const char * fn)
 { 
-  if (NULL == s or NULL == fn)
+  if (NULL == s || NULL == fn)
     return true;
 
   if (sig_file_open(s,fn))
@@ -405,9 +405,9 @@ bool match_compare_unknown(state *s, const char * fn)
   {
     Filedata *f;
     status = sig_file_next(s,&f);
-    if (not status)
+    if (! status)
       match_compare(s,f);
-  } while (not sig_file_end(s));
+  } while (! sig_file_end(s));
 
   sig_file_close(s);
 

--- a/ssdeep.h
+++ b/ssdeep.h
@@ -22,6 +22,7 @@
 
 // This is a kludge, but it works.
 #define __progname "ssdeep"
+#define VERSION "2.14.1"
 
 #define SSDEEPV1_0_HEADER        "ssdeep,1.0--blocksize:hash:hash,filename"
 #define SSDEEPV1_1_HEADER        "ssdeep,1.1--blocksize:hash:hash,filename"


### PR DESCRIPTION
- fixes for Win32