### PR TITLE
build: remove LDFLAGS=-static from ssdeep

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -2,7 +2,6 @@
 bin_PROGRAMS=ssdeep
 
 ssdeep_LDADD=libfuzzy.la
-ssdeep_LDFLAGS=-static
 
 ACLOCAL_AMFLAGS = -I m4
 


### PR DESCRIPTION
Libtool is capable of selecting the right library to use based on selected
mode. The preferred is shared if available.

Control of shared/static is to be done using --enable-shared/--enable-static
autoconf options and not brute force in application.

In current implementation using --disable-static causes libtool to confuse and
not perform relink when installing leaving RUNPATH of build directory in
executable, this is because there is no static library while injecting
--static unconditionally.

Best practice is to let libtool to produce the best setup, if there is shared
use it if no use static.

If for some reason fully static executable is required, then the functionality
should be enabled only when --enable-static is specified.

Signed-off-by: Alon Bar-Lev <alon.barlev@gmail.com>