### PR TITLE
Add include guards for main.h

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,8 @@
+2019-02-16: Jesse Kornblum <research@jessekornblum.com>:
+
+	* Makefile.am, fuzzy.c, main.h: Add proper build guards for include
+	  statememnts, remove include dependencies.
+
 2017-11-28: Travis Finkenauer <tmfink@juniper.net>:
 
 	* edit_dist.c: Include edit_dist.h to pick up forward declaration of

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,7 +6,7 @@ ssdeep_LDADD=libfuzzy.la
 ACLOCAL_AMFLAGS = -I m4
 
 lib_LTLIBRARIES=libfuzzy.la
-libfuzzy_la_SOURCES=fuzzy.c edit_dist.c find-file-size.c
+libfuzzy_la_SOURCES=fuzzy.c edit_dist.c
 libfuzzy_la_LDFLAGS=-no-undefined -version-info 3:0:1
 
 include_HEADERS=fuzzy.h edit_dist.h
@@ -15,7 +15,8 @@ man_MANS=ssdeep.1
 
 ssdeep_SOURCES = main.cpp match.cpp engine.cpp filedata.cpp   	\
                  dig.cpp cycles.cpp helpers.cpp ui.cpp edit_dist.h     	\
-                 main.h fuzzy.h tchar-local.h ssdeep.h filedata.h match.h
+                 main.h fuzzy.h tchar-local.h ssdeep.h filedata.h match.h \
+		 find-file-size.c
 
 dll: $(libfuzzy_la_SOURCES)
 	$(CC) $(CFLAGS) -shared -o fuzzy.dll $(libfuzzy_la_SOURCES) \

--- a/NEWS
+++ b/NEWS
@@ -1,3 +1,9 @@
+** Version 2.14.2 - TO BE DETERMINED
+
+* Bug Fixes
+
+  - Improved guards for including header files from the config
+
 ** Version 2.14.1 - 7 Nov 2017
 
 * Bug Fixes

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([ssdeep],[2.14.1],[floss_ssdeep@irq.a4lg.com])
+AC_INIT([ssdeep],[2.14.2],[floss_ssdeep@irq.a4lg.com])
 AM_INIT_AUTOMAKE
 
 AC_CONFIG_FILES([Makefile])

--- a/fuzzy.c
+++ b/fuzzy.c
@@ -38,6 +38,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/types.h>
 
 #include "fuzzy.h"
 #include "edit_dist.h"

--- a/fuzzy.c
+++ b/fuzzy.c
@@ -23,7 +23,13 @@
  *     http://ssdeep.sf.net/
  */
 
-#include "main.h"
+#ifndef MIN
+#define MIN(a,b) ((a)<(b)?(a):(b))
+#endif
+
+#ifndef MAX
+#define MAX(a,b) ((a)>(b)?(a):(b))
+#endif
 
 #include <assert.h>
 #include <errno.h>

--- a/main.h
+++ b/main.h
@@ -98,14 +98,5 @@
 #define FALSE  0
 #define TRUE   1
 
-#ifndef MIN
-#define MIN(a,b) ((a)<(b)?(a):(b))
-#endif
-
-#ifndef MAX
-#define MAX(a,b) ((a)>(b)?(a):(b))
-#endif
-
-
 
 #endif   // #ifndef __MAIN_H

--- a/main.h
+++ b/main.h
@@ -26,13 +26,21 @@
 
 #include <stdio.h>
 #include <stdlib.h>
-#include <string.h>
+#ifdef HAVE_STRING_H
+# include <string.h>
+#endif
 #include <errno.h>
 #include <limits.h>
-#include <sys/stat.h>
-#include <unistd.h>
+#ifdef HAVE_SYS_STAT_H
+# include <sys/stat.h>
+#endif
+#ifdef HAVE_UNISTD_H
+# include <unistd.h>
+#endif
 #include <ctype.h>
-#include <inttypes.h>
+#ifdef HAVE_INTTYPES_H
+# include <inttypes.h>
+#endif
 
 #ifdef HAVE_DIRENT_H
 # include <dirent.h>

--- a/ssdeep.1
+++ b/ssdeep.1
@@ -1,4 +1,4 @@
-.TH SSDEEP "1" "Version 2.14.1 \- 7 Nov 2017" "ssdeep Project" "SSDEEP COMMAND"
+.TH SSDEEP "1" "Version 2.14.2 \- TO BE DETERMINED" "ssdeep Project" "SSDEEP COMMAND"
 
 .SH NAME
 ssdeep - Computes context triggered piecewise hashes (fuzzy hashes)


### PR DESCRIPTION
The configure script checks for a few header files and creates compiler definitions for them in config.h. This diff ensures we use the checks for those headers and, if they are not present, don't include the headers.